### PR TITLE
changed buffer to memoryview

### DIFF
--- a/instrumental/drivers/spectrometers/thorlabs_ccs.py
+++ b/instrumental/drivers/spectrometers/thorlabs_ccs.py
@@ -290,7 +290,7 @@ class CCS(Spectrometer):
     def _cdata_to_numpy(self, cdata, data_type=float, size=None):
         if size is None:
             size = self._NiceCCSLib.TLCCS_NUM_PIXELS*BYTES_PER_DOUBLE
-        buf = buffer(ffi.buffer(ffi.addressof(cdata), size)[:])
+        buf = memoryview(ffi.buffer(ffi.addressof(cdata), size)[:])
         return np.frombuffer(buf, data_type)
 
     def _get_raw_scan_data(self):


### PR DESCRIPTION
buffer function is deprecated in python3, substitute is memoryview. TODO: check whether this would not cause other issues in the code.